### PR TITLE
feat: filepath to .env is optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,13 +9,12 @@ import (
 
 func main() {
 
-	envPath := ".env"
-	recipients := []string{"insert some email"}
+	recipients := []string{"some mails"}
 	subject := "sub"
 	body := "some text"
 	message := smtpclient.BuildMessage(recipients, subject, body)
 
-	client, err := smtpclient.BuildClient(envPath)
+	client, err := smtpclient.BuildClient()
 
 	if err != nil {
 		log.Fatal(err)

--- a/smptclient/build.go
+++ b/smptclient/build.go
@@ -43,9 +43,9 @@ func createPlainAuthentication(client smptConfig) smtp.Auth {
 
 // BuildClient loads environment variables and creates a configured SMTP client.
 // It returns the client and any errors encountered during the process.
-func BuildClient(envPath string) (Client, error) {
+func BuildClient(filepath ...string) (Client, error) {
 
-	if err := godotenv.Load(envPath); err != nil {
+	if err := godotenv.Load(filepath...); err != nil {
 		return &smptClient{}, fmt.Errorf("an error has occured while loading env variables: %w", err)
 	}
 


### PR DESCRIPTION
The smtp client builder receives arbitrary filepaths to the .env 
By default the .env that belongs to the root directory will be load